### PR TITLE
docs: add Related Resources section (Helldivers 2 Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Related Resources
+
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.


### PR DESCRIPTION
Thanks for building the Helldivers Training Manual — it's genuinely helpful for players learning stratagems.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_end`.)_